### PR TITLE
Laravue-core runnable in a subfolder

### DIFF
--- a/src/Console/SetupCommand.php
+++ b/src/Console/SetupCommand.php
@@ -53,7 +53,7 @@ class SetupCommand extends Command
         if (Str::contains(file_get_contents($path), 'BASE_API') === false) {
             // update existing entry
             file_put_contents($path, PHP_EOL . 'LARAVUE_PATH=', FILE_APPEND);
-            file_put_contents($path, PHP_EOL . 'MIX_LARAVUE_PATH="${LARAVUE_PATH}"' . PHP_EOL . PHP_EOL, FILE_APPEND);
+            file_put_contents($path, PHP_EOL . 'MIX_LARAVUE_PATH="${LARAVUE_PATH}"' . PHP_EOL, FILE_APPEND);
             file_put_contents($path, PHP_EOL . 'BASE_API=/api', FILE_APPEND);
             file_put_contents($path, PHP_EOL . 'MIX_BASE_API="${LARAVUE_PATH}${BASE_API}"', FILE_APPEND);
             $this->comment('Your BASE_API /api has been set successfully');

--- a/src/Console/SetupCommand.php
+++ b/src/Console/SetupCommand.php
@@ -69,7 +69,7 @@ class SetupCommand extends Command
         } else {
             // update default 'api' prefix
             $contents = Str::replaceFirst('use Illuminate\Support\Facades\Route;', 'use Illuminate\Support\Facades\Route;' . PHP_EOL . 'use Illuminate\Support\Str;', $contents);
-            $contents = Str::replaceFirst('Route::prefix(\'api\')', 'Route::prefix((Str::finish(env(\'LARAVUE_PATH\'), \'/\') !== \'/\' ?: \'\') . 'api')', $contents);
+            $contents = Str::replaceFirst('Route::prefix(\'api\')', 'Route::prefix((Str::finish(env(\'LARAVUE_PATH\'), \'/\') !== \'/\' ?: \'\') . \'api\')', $contents);
             file_put_contents($path, $contents);
             $this->comment('Your RouteServiceProvider.php has been updated successfully');
         }

--- a/src/Console/SetupCommand.php
+++ b/src/Console/SetupCommand.php
@@ -60,6 +60,17 @@ class SetupCommand extends Command
             return;
         }
 
+        $path = $this->laravel->basePath('app/Providers/RouteServiceProvider.php');
+        if (Str::contains($contents = file_get_contents($path), "Route::prefix('api')") === false) {
+            $this->comment('Your RouteServiceProvider.php is missing its Route::prefix(\'api\'), please ensure that you\'re working with a base Laravel project setup.');
+            return;
+        } else {
+            // update default 'api' prefix
+            $contents = Str::replaceFirst('Route::prefix(\'api\')', 'Route::prefix(env(\'LARAVUE_PATH\') . \'api\')', $contents);
+            file_put_contents($path, $contents);
+            $this->comment('Your RouteServiceProvider.php has been updated successfully');
+        }
+        
         $this->setupBabel();
         $this->setupPackages();
         $this->setupDependencies();

--- a/src/Console/SetupCommand.php
+++ b/src/Console/SetupCommand.php
@@ -52,8 +52,10 @@ class SetupCommand extends Command
 
         if (Str::contains(file_get_contents($path), 'BASE_API') === false) {
             // update existing entry
+            file_put_contents($path, PHP_EOL . 'LARAVUE_PATH=', FILE_APPEND);
+            file_put_contents($path, PHP_EOL . 'MIX_LARAVUE_PATH="${LARAVUE_PATH}"' . PHP_EOL . PHP_EOL, FILE_APPEND);
             file_put_contents($path, PHP_EOL . 'BASE_API=/api', FILE_APPEND);
-            file_put_contents($path, PHP_EOL . 'MIX_BASE_API="${BASE_API}"', FILE_APPEND);
+            file_put_contents($path, PHP_EOL . 'MIX_BASE_API="${LARAVUE_PATH}${BASE_API}"', FILE_APPEND);
             $this->comment('Your BASE_API /api has been set successfully');
         } else {
             $this->comment('Your BASE_API already exists, please make sure Laravue will work with this endpoint.');
@@ -66,7 +68,8 @@ class SetupCommand extends Command
             return;
         } else {
             // update default 'api' prefix
-            $contents = Str::replaceFirst('Route::prefix(\'api\')', 'Route::prefix(env(\'LARAVUE_PATH\') . \'api\')', $contents);
+            $contents = Str::replaceFirst('use Illuminate\Support\Facades\Route;', 'use Illuminate\Support\Facades\Route;' . PHP_EOL . 'use Illuminate\Support\Str;', $contents);
+            $contents = Str::replaceFirst('Route::prefix(\'api\')', 'Route::prefix((Str::finish(env(\'LARAVUE_PATH\'), \'/\') !== \'/\' ?: \'\') . 'api')', $contents);
             file_put_contents($path, $contents);
             $this->comment('Your RouteServiceProvider.php has been updated successfully');
         }


### PR DESCRIPTION
No 404 error anymore when traying to log in from a subfolder 
(like `https://localhost/LaravuCoreTest/public`. The LARAVUE_PATH in the .env file must be set like this `LARAVUE_PATH=/LaravueCoreTest/public`.)